### PR TITLE
Adds a workaround to fix the styling problem when adding header and foot...

### DIFF
--- a/lib/rasterize/rasterize.js
+++ b/lib/rasterize/rasterize.js
@@ -67,7 +67,7 @@ if (system.args.length < 3 || system.args.length > 6) {
 				}, headerOrFooter);
 				if (typeOfContent === "string" || typeOfContent === "function") {
 					contents = phantom.callback(function (pageNum, numPages) {
-						return getHtmlWithInlineStyle(headerOrFooter, pageNum, numPages);
+						return getHtmlWithStyles(headerOrFooter, pageNum, numPages);
 					});
 				} else {
 					console.error("html2pdf." + headerOrFooter + ".contents has wrong type: " + typeOfContent);
@@ -81,7 +81,7 @@ if (system.args.length < 3 || system.args.length > 6) {
 			}
 		}
 
-		function getHtmlWithInlineStyle(headerOrFooter, pageNumber, totalPages) {
+		function getHtmlWithStyles(headerOrFooter, pageNumber, totalPages) {
 			return page.evaluate(function (headerOrFooter, pageNumber, totalPages) {
 				var contents = html2pdf[headerOrFooter].contents;
 				var html = typeof contents === "string" ?
@@ -90,18 +90,29 @@ if (system.args.length < 3 || system.args.length > 6) {
 				html = html
 					.replace(/\{\{pagenumber\}\}/gi, pageNumber)
 					.replace(/\{\{totalpages\}\}/gi, totalPages);
+
+				//footer/Header container
 				var host = document.createElement('div');
 				host.innerHTML = html;
-				document.body.appendChild(host);
-				var elements = host.getElementsByTagName('*');
-				for (var i in elements) {
-					if (elements[i].className) {
-						elements[i].setAttribute('style', window.getComputedStyle(elements[i], null).cssText);
-					}
+
+				var styleFiles = document.getElementsByTagName('link');
+
+				for (var i = 0; i < styleFiles .length; i++) {
+					var linkEl = styleFiles[i];
+					var newStyle = document.createElement("style");
+					newStyle.setAttribute('type', 'text/css');
+
+					//Get the "text" (css properties) of each link href file.
+					var xhReq = new XMLHttpRequest();
+					xhReq.open("GET", linkEl.href, false);
+					xhReq.send(null);
+					var serverResponse = xhReq.responseText;
+
+					newStyle.innerHTML = serverResponse;
+
+					host.appendChild(newStyle);
 				}
-				host.setAttribute('style', window.getComputedStyle(host, null).cssText);
-				document.body.removeChild(host);
-				document.body.setAttribute('style', window.getComputedStyle(document.body, null).cssText); //this is needed to re-render body
+
 				return host.outerHTML;
 			}, headerOrFooter, pageNumber, totalPages);
 		}


### PR DESCRIPTION
The commit fixes a bug that was causing that certain css properties were removed in the whole page overwrote by the function "getHtmlWithInlineStyle" if there was footer or header in the pdf.

It also remove the "body refresh" that was causing that sometimes the pdf page does not draw.

It fixes the problem:
https://github.com/Muscula/html2pdf.it/issues/13
https://github.com/Muscula/html2pdf.it/issues/14
so now one can add only a header or a footer, not always both like before.
